### PR TITLE
Merging GrantMStevens fix for isDefined

### DIFF
--- a/source/js/ng-img-crop.js
+++ b/source/js/ng-img-crop.js
@@ -37,9 +37,7 @@ crop.directive('imgCrop', ['$timeout', 'cropHost', 'cropPubSub', function($timeo
         var resultImage=cropHost.getResultImageDataURI();
         if(storedResultImage!==resultImage) {
           storedResultImage=resultImage;
-          if(angular.isDefined(scope.resultImage)) {
-            scope.resultImage=resultImage;
-          }
+          scope.resultImage=resultImage;
           scope.onChange({$dataURI: scope.resultImage});
         }
       };


### PR DESCRIPTION
Removing the isDefined check for scope.resultImage. I should not be required to define the property I bind to the resultImage object to. This is a very unnecessary requirement to place upon your users and it can cause issues when using complex javascript objects which do not have their entire structure predefined in code.
